### PR TITLE
gitlab - not not add/remove undefined labels

### DIFF
--- a/webhook-server-container/github_api.py
+++ b/webhook-server-container/github_api.py
@@ -36,7 +36,8 @@ class GitHubApi:
         self.clone_repository_path = os.path.join("/", self.repository.name)
         self.reviewed_by_prefix = "-by-"
         self.auto_cherry_pick_prefix = "auto-cherry-pick:"
-        self.welcome_msg = """
+        supported_user_labels_str = "\n".join(STATIC_LABELS_DICT.keys())
+        self.welcome_msg = f"""
 The following are automatically added:
  * Add reviewers from OWNER file (in the root of the repository) under reviewers section.
  * Set PR size label.
@@ -46,6 +47,8 @@ Available user actions:
  * To mark PR as verified add `!verified` to a PR comment, to un-verify add `!-verified` to a PR comment.
         Verified label removed on each new commit push.
  * To cherry pick a merged PR add `!cherry-pick <target branch to cherry-pick to>` to a PR comment.
+ * To add a label by comment use `!<label name>`, to remove, use `!-<label name>`
+        Supported labels: {supported_user_labels_str}
             """
 
     def process_hook(self, data):

--- a/webhook-server-container/github_api.py
+++ b/webhook-server-container/github_api.py
@@ -7,7 +7,7 @@ from contextlib import contextmanager
 
 import requests
 import yaml
-from constants import ALL_LABELS_DICT
+from constants import ALL_LABELS_DICT, STATIC_LABELS_DICT
 from github import Github, GithubException
 from github.GithubException import UnknownObjectException
 
@@ -208,7 +208,8 @@ Available user actions:
 
         try:
             self.app.logger.info(
-                f"{self.repository_name}: Cherry picking {commit_hash} into {source_branch}, requested by {user_login}"
+                f"{self.repository_name}: Cherry picking {commit_hash} into {source_branch}, requested by "
+                f"{user_login}"
             )
             with change_directory(repo_path):
                 cherry_pick = subprocess.Popen(
@@ -341,6 +342,12 @@ Available user actions:
 
         # Skip sonar tests comments
         if "sonarsource.github.io" in _label:
+            return
+
+        if not any(_label in label_name for label_name in STATIC_LABELS_DICT):
+            self.app.logger.info(
+                f"Label {_label} is not a predefined one, will not be added / removed."
+            )
             return
 
         self.app.logger.info(

--- a/webhook-server-container/gitlab_api.py
+++ b/webhook-server-container/gitlab_api.py
@@ -118,7 +118,7 @@ Available user actions:
             )
             return
 
-            # Remove label
+        # Remove label
         if user_request[0] == "-":
             self.app.logger.info(
                 f"{self.repo_mr_log_message} Label removal requested by user: {_label}"

--- a/webhook-server-container/gitlab_api.py
+++ b/webhook-server-container/gitlab_api.py
@@ -29,7 +29,8 @@ class GitLabApi:
         )
         self.user = self.hook_data["user"]
         self.username = self.user["username"]
-        self.welcome_msg = """
+        supported_user_labels_str = "\n".join(STATIC_LABELS_DICT.keys())
+        self.welcome_msg = f"""
 ** AUTOMATED **
 This is automated comment.
 
@@ -44,6 +45,8 @@ Available user actions:
         Verified label removed on each new commit push.
  * To approve an MR, either use the `Approve` button or add `!LGTM` or `!lgtm` to the MR comment.
  * To remove approval, either use the `Revoke approval` button or add `!-LGTM` or `!-lgtm` to the MR comment.
+  * To add a label by comment use `!<label name>`, to remove, use `!-<label name>`
+        Supported labels: {supported_user_labels_str}
             """
 
         # Always make sure that the repository's merge requests "All threads must be resolved" setting is enabled

--- a/webhook-server-container/gitlab_api.py
+++ b/webhook-server-container/gitlab_api.py
@@ -112,9 +112,9 @@ Available user actions:
 
     def label_by_user_comment(self, user_request):
         _label = user_request[1]
-        if _label not in STATIC_LABELS_DICT:
+        if not any(_label in label_name for label_name in STATIC_LABELS_DICT):
             self.app.logger.info(
-                f"Label {_label} is not a predefined one, not adding it."
+                f"Label {_label} is not a predefined one, will not be added / removed."
             )
             return
 

--- a/webhook-server-container/gitlab_api.py
+++ b/webhook-server-container/gitlab_api.py
@@ -4,7 +4,7 @@ import re
 import gitlab
 import requests
 import yaml
-from constants import DYNAMIC_LABELS_DICT
+from constants import DYNAMIC_LABELS_DICT, STATIC_LABELS_DICT
 from gitlab.exceptions import GitlabUpdateError
 
 
@@ -112,8 +112,13 @@ Available user actions:
 
     def label_by_user_comment(self, user_request):
         _label = user_request[1]
+        if _label not in STATIC_LABELS_DICT:
+            self.app.logger.info(
+                f"Label {_label} is not a predefined one, not adding it."
+            )
+            return
 
-        # Remove label
+            # Remove label
         if user_request[0] == "-":
             self.app.logger.info(
                 f"{self.repo_mr_log_message} Label removal requested by user: {_label}"


### PR DESCRIPTION
Avoid adding / removing labels that meet the "!" or "!-" pattern but are not defined as supported gitlab labels by this repo.